### PR TITLE
Do not overwrite Caps_Lock as CtrlL_Lock

### DIFF
--- a/Keyboard/ckbcomp
+++ b/Keyboard/ckbcomp
@@ -196,11 +196,8 @@ my %acmtable; # Unicode -> legacy code (defined only when -charmap is given)
 
 my $KEYMAP = ''; # This variable contains the generated keymap
 
-my $broken_caps = 0; # In unicode mode Caps_Lock doesn't work for non-ASCII
-                     # letters.  1 = the keymap contains non-ascii letters.
-                     # See http://bugzilla.kernel.org/show_bug.cgi?id=7746#c21
-
 my %keycodes_table; # x keysym -> x key code
+
 my %aliases;        # x keysym -> x keysym
 
 my %symbols_table;   # x key code -> [[symbols for group0,...],
@@ -4376,9 +4373,6 @@ sub print_vector {
 		my $u = ord (uc (pack ("U", $v)));
 		my $c = ($v == $l ? $u : $l);
 		$capsvector[$mask] = $1 ."U+". sprintf ("%04x", $c);
-		if ($v != $c && $v gt 0x7f) {
-		    $broken_caps = 1;
-		}
 	    }
 	}
 	if ($no_NoSymbol) {
@@ -4774,10 +4768,6 @@ keycode 127 =
     }
 } else {
     die "$0: Unsupported keyboard type $arch\n";
-}
-
-if ($broken_caps) {
-    $KEYMAP =~ s/Caps_Lock/CtrlL_Lock/g;
 }
 
 print $KEYMAP;


### PR DESCRIPTION
This was done as a stop-gap for capitalizing keys via caps
while the teminal is in unicode mode. It seems that this
was fixed years ago (after this check was added), but then this
check was never removed here.